### PR TITLE
config/common: Fix definition of firmware path

### DIFF
--- a/config/common.mk
+++ b/config/common.mk
@@ -274,7 +274,7 @@ $(call inherit-product, vendor/pixel-framework/config.mk)
 # Conditionally include firmware config.mk file
 TARGET_SHIPS_FIRMWARE ?= false
 ifeq ($(TARGET_SHIPS_FIRMWARE),true)
-$(call inherit-product, vendor/firmware/include/config.mk)
+$(call inherit-product, vendor/firmware/$(EVOLUTION_BUILD)/config.mk)
 endif
 
 -include $(WORKSPACE)/build_env/image-auto-bits.mk


### PR DESCRIPTION
```
In file included from build/make/core/config.mk:352:
In file included from build/make/core/envsetup.mk:352:
In file included from vendor/evolution/config/common_full.mk:4:
vendor/evolution/config/common.mk:277: error:  vendor/firmware/include/config.mk does not exist..
```