### PR TITLE
envestup: Always use `python3` when executing `repopick`

### DIFF
--- a/build/envsetup.sh
+++ b/build/envsetup.sh
@@ -600,7 +600,7 @@ alias cmkap='dopush cmka'
 
 function repopick() {
     T=$(gettop)
-    $T/vendor/evolution/build/tools/repopick.py $@
+    python3 $T/vendor/evolution/build/tools/repopick.py $@
 }
 
 function sort-blobs-list() {


### PR DESCRIPTION
* Otherwise we get "permission denied" as the file doesn't have the executable bit set.